### PR TITLE
Add Watchman FLX device to cardiac device simulator

### DIFF
--- a/AsdVsdDeviceSimulator/AsdVsdDeviceSimulator.py
+++ b/AsdVsdDeviceSimulator/AsdVsdDeviceSimulator.py
@@ -17,7 +17,7 @@ class AsdVsdDeviceSimulator(ScriptedLoadableModule):
   """
 
   deviceClasses = [SeptalOccluder, MultiFenestratedSeptalOccluder,
-                   DuctOccluder, DuctOccluderII, MuscularVSDOccluder, CustomDevice]
+                   DuctOccluder, DuctOccluderII, MuscularVSDOccluder, CustomDevice, WatchmanFlxDevice]
 
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)

--- a/AsdVsdDeviceSimulator/AsdVsdDevices/devices.py
+++ b/AsdVsdDeviceSimulator/AsdVsdDevices/devices.py
@@ -279,3 +279,52 @@ class CustomDevice(CardiacDeviceBase):
     points.InsertNextPoint(0, 0, halfLength)
 
     return points
+
+
+class WatchmanFlxDevice(CardiacDeviceBase):
+
+  NAME = "Watchman FLX"
+  ID = "WatchmanFlx"
+  RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "..",  "Resources")
+
+  @classmethod
+  def getParameters(cls):
+    return {
+      'diameterMm': cls._genParameters("Diameter", "Diameter of the device", 27, "mm", 20, 35, 1, 0),
+      'lengthMm': cls._genParameters("Length", "Total length", 20, "mm", 10, 30, 1, 0),
+      'waistDiameterMm': cls._genParameters("Waist diameter", "Diameter of the waist", 20, "mm", 10, 30, 1, 0),
+      'waistLengthMm': cls._genParameters("Waist length", "Length of the waist", 10, "mm", 5, 15, 1, 0),
+      'skirtLengthFraction': cls._genParameters("Skirt length", "Percentage of skirt length relative to total length", 20, "%", 0, 200, 1, 5),
+      'skirtRadiusFraction': cls._genParameters("Skirt radius", "Percentage of radius of skirt compared to the base radius", 20, "%", 0, 200, 1, 5)
+    }
+
+  @classmethod
+  def getInternalParameters(cls):
+    return {'interpolationSmoothness': -0.70}
+
+  @staticmethod
+  def getProfilePoints(params, segment=None, openSegment=True):
+    lengthMm = params['lengthMm']
+    radiusMm = params['diameterMm'] / 2.0
+    waistRadiusMm = params['waistDiameterMm'] / 2.0
+    halfWaistLength = params['waistLengthMm'] / 2.0
+    skirtLengthFraction = params['skirtLengthFraction']
+    skirtRadiusFraction = params['skirtRadiusFraction']
+
+    points = vtk.vtkPoints()
+
+    halfLength = lengthMm * 0.5
+
+    # Skirt
+    points.InsertNextPoint(radiusMm * (1.0 + skirtRadiusFraction), 0, -halfLength + lengthMm * skirtLengthFraction)
+
+    # Main body
+    points.InsertNextPoint(radiusMm, 0, -halfLength)
+    points.InsertNextPoint(radiusMm, 0, -halfWaistLength)
+    points.InsertNextPoint(waistRadiusMm, 0, -halfWaistLength)
+    points.InsertNextPoint(waistRadiusMm, 0, halfWaistLength)
+    points.InsertNextPoint(radiusMm, 0, halfWaistLength)
+    points.InsertNextPoint(radiusMm, 0, halfLength)
+    points.InsertNextPoint(0, 0, halfLength)
+
+    return points

--- a/AsdVsdDeviceSimulator/Resources/Presets/WatchmanFlx.csv
+++ b/AsdVsdDeviceSimulator/Resources/Presets/WatchmanFlx.csv
@@ -1,0 +1,6 @@
+Model,diameterMm,lengthMm,waistDiameterMm,waistLengthMm
+FLX-20,20,10,20,5
+FLX-24,24,12,24,6
+FLX-27,27,14,27,7
+FLX-30,30,16,30,8
+FLX-35,35,18,35,9


### PR DESCRIPTION
Add the Watchman FLX device to the cardiac device simulator.

* Add a new class `WatchmanFlxDevice` in `AsdVsdDeviceSimulator/AsdVsdDevices/devices.py` to define the Watchman FLX device.
* Implement the `getParameters`, `getInternalParameters`, and `getProfilePoints` methods in the `WatchmanFlxDevice` class.
* Register the `WatchmanFlxDevice` class in the `AsdVsdDeviceSimulator` class in `AsdVsdDeviceSimulator/AsdVsdDeviceSimulator.py`.
* Add the `WatchmanFlxDevice` to the `deviceClasses` list in `AsdVsdDeviceSimulator/AsdVsdDeviceSimulator.py`.
* Create a CSV file `AsdVsdDeviceSimulator/Resources/Presets/WatchmanFlx.csv` for the Watchman FLX device presets with default parameter values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jamesgoldfarb/SlicerHeart_laac?shareId=822626ec-884e-47ec-94fb-e7c58e1eac94).